### PR TITLE
Use Long Polling

### DIFF
--- a/part1/echobot.py
+++ b/part1/echobot.py
@@ -23,9 +23,9 @@ def get_json_from_url(url):
 
 
 def get_updates(offset=None):
-    url = URL + "getUpdates"
+    url = URL + "getUpdates?timeout=100"
     if offset:
-        url += "?offset={}".format(offset)
+        url += "&offset={}".format(offset)
     js = get_json_from_url(url)
     return js
 


### PR DESCRIPTION
It is best practice not to flood Telegram's servers with requests, when you can use Long Polling.